### PR TITLE
fixed missing types when first time compiling

### DIFF
--- a/php_forp.h
+++ b/php_forp.h
@@ -47,6 +47,8 @@ extern zend_module_entry forp_module_entry;
 #include "TSRM.h"
 #endif
 
+#include "forp.h"
+
 PHP_MINIT_FUNCTION(forp);
 PHP_MSHUTDOWN_FUNCTION(forp);
 PHP_RINIT_FUNCTION(forp);


### PR DESCRIPTION
Will fix the follow errors on first time compiling:

``` shell
php_forp.h:71:2: error: unknown type name ‘forp_node_t’
php_forp.h:72:2: error: unknown type name ‘forp_node_t’
php_forp.h:74:2: error: unknown type name ‘forp_node_t’
php_forp.h:82:5: error: unknown type name ‘forp_var_t
```
